### PR TITLE
Configurable Ronne ID

### DIFF
--- a/src/main/java/com/crypticmushroom/planetbound/config/ConfigHandler.java
+++ b/src/main/java/com/crypticmushroom/planetbound/config/ConfigHandler.java
@@ -3,14 +3,19 @@ package com.crypticmushroom.planetbound.config;
 import com.crypticmushroom.planetbound.PBCore;
 import com.crypticmushroom.planetbound.logger.PBLogDev;
 import com.crypticmushroom.planetbound.logger.PBLogger;
+import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 /*
  * Config Handler by Jonathan
  */
 
+@Config(modid = PBCore.MOD_ID)
+@Mod.EventBusSubscriber(modid = PBCore.MOD_ID)
 public class ConfigHandler {
+    private static final String configKey = PBCore.MOD_ID + ".config.";
     private static boolean checkDevMode = getAutoDevMode(PBCore.VERSION);
 
     public static void loadConfig(FMLPreInitializationEvent event) {
@@ -60,5 +65,14 @@ public class ConfigHandler {
                 PBLogDev.printInfo("Developer Mode logging will continue at the DEBUG level.");
             }
         }
+    }
+
+    public static Dimension dimension = new Dimension();
+
+    public static class Dimension {
+        @Config.LangKey(configKey + "dimension_id_ronne")
+        @Config.RequiresMcRestart
+        @Config.Comment("Set the Dimension ID for Ronne. Will require a restart for effects to take place.")
+        public int dimensionIDRonne = 4;
     }
 }

--- a/src/main/java/com/crypticmushroom/planetbound/init/PBWorld.java
+++ b/src/main/java/com/crypticmushroom/planetbound/init/PBWorld.java
@@ -1,5 +1,6 @@
 package com.crypticmushroom.planetbound.init;
 
+import com.crypticmushroom.planetbound.config.ConfigHandler;
 import com.crypticmushroom.planetbound.world.WorldProviderRonne;
 import com.crypticmushroom.planetbound.world.biome.BiomeRedDesert;
 import com.crypticmushroom.planetbound.world.gen.PBOreGenerator;
@@ -13,7 +14,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 
 @EventBusSubscriber
 public class PBWorld {
-    public static final int RONNE_ID = 4; //TODO make this configurable
+    public static final int RONNE_ID = ConfigHandler.dimension.dimensionIDRonne;
 
     public static final DimensionType RONNE = DimensionType.register("ronne", "ronne", RONNE_ID, WorldProviderRonne.class, false);
 


### PR DESCRIPTION
This makes the ID for Ronne configurable. The line `ConfigHandler.dimension.dimensionIDRonne` will need to be added wherever the Dimension ID for Ronne is needed. What this will do is listen to the Config file instead of a static number.

Also adds a Config file because it wasn't annotated to do so, and clears up a TODO from code.