### PR TITLE
refactored networking and use vanilla cooldown tracker for rift gauntlet

### DIFF
--- a/src/main/java/com/crypticmushroom/planetbound/networking/packet/PBPacket.java
+++ b/src/main/java/com/crypticmushroom/planetbound/networking/packet/PBPacket.java
@@ -5,26 +5,26 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
-import net.minecraftforge.fml.relauncher.Side;
 
-public abstract class PBPacket<Message extends IMessage> implements IMessage, IMessageHandler<Message, Message>
+public abstract class PBPacket<Message extends IMessage> implements IMessage, IMessageHandler<Message, IMessage>
 {
     @Override
-    public Message onMessage(Message message, MessageContext context)
+    public IMessage onMessage(Message message, MessageContext context)
     {
-        if(context.side == Side.CLIENT)
-        {
-            handleClient(message, PBCore.proxy.thePlayer());
+        switch (context.side) {
+            case CLIENT:
+                return handleClient(message, PBCore.proxy.thePlayer());
+            case SERVER:
+                return handleServer(message, context.getServerHandler().player);
         }
-        else if(context.side == Side.SERVER)
-        {
-            handleServer(message, context.getServerHandler().player);
-        }
-
         return null;
     }
 
-    public abstract void handleClient(Message message, EntityPlayer player);
+    public IMessage handleClient(Message message, EntityPlayer player) {
+        return null;
+    }
 
-    public abstract void handleServer(Message message, EntityPlayer player);
+    public IMessage handleServer(Message message, EntityPlayer player) {
+        return null;
+    }
 }

--- a/src/main/java/com/crypticmushroom/planetbound/networking/packet/PBPacketOpenContainer.java
+++ b/src/main/java/com/crypticmushroom/planetbound/networking/packet/PBPacketOpenContainer.java
@@ -4,6 +4,7 @@ import com.crypticmushroom.planetbound.PBCore;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 
 public class PBPacketOpenContainer extends PBPacket<PBPacketOpenContainer>
 {
@@ -31,16 +32,10 @@ public class PBPacketOpenContainer extends PBPacket<PBPacketOpenContainer>
     }
 
     @Override
-    public void handleClient(PBPacketOpenContainer message, EntityPlayer player)
-    {
-
-    }
-
-    @Override
-    public void handleServer(PBPacketOpenContainer message, EntityPlayer player)
+    public IMessage handleServer(PBPacketOpenContainer message, EntityPlayer player)
     {
         BlockPos pos = player.getPosition();
-
         player.openGui(PBCore.instance(), message.id, player.world, pos.getX(), pos.getY(), pos.getZ());
+        return null;
     }
 }

--- a/src/main/java/com/crypticmushroom/planetbound/networking/packet/PBPacketSmeltMode.java
+++ b/src/main/java/com/crypticmushroom/planetbound/networking/packet/PBPacketSmeltMode.java
@@ -5,6 +5,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 
 public class PBPacketSmeltMode extends PBPacket<PBPacketSmeltMode>
 {
@@ -46,13 +47,7 @@ public class PBPacketSmeltMode extends PBPacket<PBPacketSmeltMode>
     }
 
     @Override
-    public void handleClient(PBPacketSmeltMode message, EntityPlayer player)
-    {
-
-    }
-
-    @Override
-    public void handleServer(PBPacketSmeltMode message, EntityPlayer player)
+    public IMessage handleServer(PBPacketSmeltMode message, EntityPlayer player)
     {
         TileEntity tileEntity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
 
@@ -60,5 +55,6 @@ public class PBPacketSmeltMode extends PBPacket<PBPacketSmeltMode>
         {
             ((TileEntityInventorsForge) tileEntity).setField(4, message.mode);
         }
+        return null;
     }
 }

--- a/src/main/java/com/crypticmushroom/planetbound/networking/packet/PBPacketSpawnRift.java
+++ b/src/main/java/com/crypticmushroom/planetbound/networking/packet/PBPacketSpawnRift.java
@@ -1,11 +1,7 @@
 package com.crypticmushroom.planetbound.networking.packet;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.crypticmushroom.planetbound.init.PBBlocks;
-import com.crypticmushroom.planetbound.player.PBPlayer;
-
+import com.crypticmushroom.planetbound.init.PBItems;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -14,7 +10,15 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.Style;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class PBPacketSpawnRift extends PBPacket<PBPacketSpawnRift>
 {
@@ -49,84 +53,54 @@ public class PBPacketSpawnRift extends PBPacket<PBPacketSpawnRift>
 	}
 
 	@Override
-	public void handleClient(PBPacketSpawnRift message, EntityPlayer player)
+	public IMessage handleServer(PBPacketSpawnRift message, EntityPlayer player)
 	{
-
-	}
-
-	@SuppressWarnings("incomplete-switch")
-	@Override
-	public void handleServer(PBPacketSpawnRift message, EntityPlayer player)
-	{
-		PBPlayer pbPlayer = PBPlayer.get(player);
-
-		int cooldown = pbPlayer.getGauntletUseCooldown();
-
-		if(cooldown <= 0)
+		if(!player.getCooldownTracker().hasCooldown(PBItems.rift_gauntlet))
 		{
 			BlockPos pos = message.pos;
-			BlockPos up = pos.up();
-
 			World world = player.world;
-
 			Block block = world.getBlockState(pos).getBlock();
-
 			EnumFacing facing = player.getHorizontalFacing();
-
 			List<BlockPos> portalBlocks = freeBlocks(pos, facing);
 
 			if(!block.equals(Blocks.AIR) && isAllAir(world, portalBlocks))
 			{
-
-				IBlockState state = PBBlocks.rift.getDefaultState();;
-				switch(facing){
-				case EAST:
-				case WEST:
+				IBlockState state = PBBlocks.rift.getDefaultState();
+				if(facing == EnumFacing.EAST || facing == EnumFacing.WEST)
+				{
 					state = state.withRotation(Rotation.CLOCKWISE_90);
 				}
-
-				for(BlockPos position : portalBlocks)
-					world.setBlockState(position, state);
-
-				pbPlayer.setGauntletUseCooldown(200);
+				final IBlockState iBlockState = state;
+				portalBlocks.forEach(blockPos -> world.setBlockState(blockPos, iBlockState));
+				player.getCooldownTracker().setCooldown(PBItems.rift_gauntlet, 200);
 			}
 		}
-		else
-		{
-			// player.sendMessage(new TextComponentString(String.format("Please wait (%s)",
-			// cooldown / 40)));
-		}
+		else player.sendStatusMessage(new TextComponentString("you cannot use this yet!").setStyle(new Style().setColor(TextFormatting.RED)), true); //should actually never happen
+		return null;
 	}
 
-	@SuppressWarnings("incomplete-switch")
 	private List<BlockPos> freeBlocks(BlockPos pos, EnumFacing facing)
 	{
-		List<BlockPos> positions = new ArrayList<>();
-
-		positions.add(pos.up());
-		positions.add(pos.up(2));
-		positions.add(pos.up(3));
-
-		switch(facing)
-		{
-		case NORTH:
-		case SOUTH:
-			for(int i = 0; i < 3; i++)
-				positions.add(positions.get(i).west());
-			break;
-		case EAST:
-		case WEST:
-			for(int i = 0; i < 3; i++)
-				positions.add(positions.get(i).north());
-		}
-
+        List<BlockPos> positions = new ArrayList<>();
+	    EnumFacing offsetFacing;
+	    switch (facing) {
+            case NORTH:
+            case SOUTH:
+                offsetFacing = EnumFacing.WEST;
+                break;
+            case WEST:
+            case EAST:
+                default: //actually never used
+                offsetFacing = EnumFacing.NORTH;
+        }
+        for(int i = 1; i <= 3; i++) {
+            positions.add(pos.up(i));
+            positions.add(pos.offset(offsetFacing, i));
+        }
 		return positions;
 	}
 
 	private boolean isAllAir(World world, List<BlockPos> blocks) {
-		for(BlockPos pos : blocks)
-			if(!world.isAirBlock(pos))
-				return false;
-		return true;
+		return blocks.stream().filter(pos -> !world.isAirBlock(pos)).collect(Collectors.toList()).size() == 0;
 	}
 }

--- a/src/main/java/com/crypticmushroom/planetbound/player/PBPlayer.java
+++ b/src/main/java/com/crypticmushroom/planetbound/player/PBPlayer.java
@@ -26,8 +26,6 @@ public class PBPlayer
     private InventoryGauntlet inventoryGauntlet;
 
     private int riftCooldown;
-    private int gauntletUseCooldown;
-
     private boolean inRift;
 
     public PBPlayer()
@@ -54,17 +52,12 @@ public class PBPlayer
     public NBTTagCompound writeToNBT(NBTTagCompound compound)
     {
         inventoryGauntlet.writeToNBT(compound);
-
-        compound.setInteger("gauntletUseCooldown", gauntletUseCooldown);
-
         return compound;
     }
 
     public void readFromNBT(NBTTagCompound compound)
     {
         inventoryGauntlet.readFromNBT(compound);
-
-        gauntletUseCooldown = compound.getInteger("gauntletUseCooldown");
     }
 
     public EntityPlayer getPlayer()
@@ -86,33 +79,6 @@ public class PBPlayer
         else
         {
             inRift = true;
-        }
-    }
-
-    public void decreaseGauntletUseCooldown(int amount)
-    {
-        if(gauntletUseCooldown > 0)
-        {
-            gauntletUseCooldown -= amount;
-        }
-        else
-        {
-            gauntletUseCooldown = 0;
-        }
-    }
-
-    public int getGauntletUseCooldown()
-    {
-        return gauntletUseCooldown;
-    }
-
-    public void setGauntletUseCooldown(int ticks)
-    {
-        gauntletUseCooldown = ticks;
-
-        if(gauntletUseCooldown < 0)
-        {
-            gauntletUseCooldown = 0;
         }
     }
 

--- a/src/main/java/com/crypticmushroom/planetbound/player/PBPlayerEventHandler.java
+++ b/src/main/java/com/crypticmushroom/planetbound/player/PBPlayerEventHandler.java
@@ -9,7 +9,6 @@ import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent.Clone;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 @EventBusSubscriber(modid = PBCore.MOD_ID)
 public class PBPlayerEventHandler
@@ -22,11 +21,7 @@ public class PBPlayerEventHandler
         if((event.getObject() instanceof EntityPlayer))
         {
             EntityPlayer player = (EntityPlayer) event.getObject();
-
-            if(PBPlayer.get(player) == null)
-            {
-                event.addCapability(PLAYER_STORAGE, new PBPlayer.Factory(new PBPlayer(player)));
-            }
+            event.addCapability(PLAYER_STORAGE, new PBPlayer.Factory(new PBPlayer(player)));
         }
     }
 
@@ -35,28 +30,11 @@ public class PBPlayerEventHandler
     {
         PBPlayer original = PBPlayer.get(event.getOriginal());
         PBPlayer clone = PBPlayer.get(event.getEntityPlayer());
-
         if(original != null)
         {
             NBTTagCompound compound = new NBTTagCompound();
-
             original.writeToNBT(compound);
-
-            if(clone != null)
-            {
-                clone.readFromNBT(compound);
-            }
-        }
-    }
-
-    @SubscribeEvent
-    public static void onPlayerUpdate(TickEvent.PlayerTickEvent event)
-    {
-        PBPlayer player = PBPlayer.get(event.player);
-
-        if(player != null && !player.getPlayer().world.isRemote)
-        {
-            player.decreaseGauntletUseCooldown(1);
+            if(clone != null) clone.readFromNBT(compound);
         }
     }
 }


### PR DESCRIPTION
- refactored networking system: made packet return type a generic `IMessage` so we could return any packet
- made gauntlet cooldown use teh vanilal cooldown tracker rather than a tick handler